### PR TITLE
🛡️ Sentinel: [HIGH] Fix vulnerable dependencies in Magick.NET and ImageSharp

### DIFF
--- a/DuplaImage.ImageMagick/DuplaImage.Lib.ImageMagick.csproj
+++ b/DuplaImage.ImageMagick/DuplaImage.Lib.ImageMagick.csproj
@@ -26,7 +26,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.6.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.13.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DuplaImage.Lib\DuplaImage.Lib.csproj" />

--- a/DuplaImage.Lib.ImageSharpTransformer/DuplaImage.Lib.ImageSharpTransformer.csproj
+++ b/DuplaImage.Lib.ImageSharpTransformer/DuplaImage.Lib.ImageSharpTransformer.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Outdated dependencies (`Magick.NET-Q8-AnyCPU` and `SixLabors.ImageSharp`) with known vulnerabilities, such as GHSA-rxmq-m78w-7wmc.
🎯 Impact: Image-processing libraries are often targets for Denial of Service, out-of-bounds reads, or buffer overflows when parsing malicious image files.
🔧 Fix: Updated `Magick.NET-Q8-AnyCPU` to 14.13.1 and `SixLabors.ImageSharp` to 3.1.12 to mitigate these CVEs.
✅ Verification: `dotnet list package --vulnerable` now reports no vulnerable packages.

---
*PR created automatically by Jules for task [16008214406506100827](https://jules.google.com/task/16008214406506100827) started by @MrSquirrely*