### PR TITLE
⚡ Bolt: Optimize median hash calculations with stackalloc Span<T>

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-26 - Span<T> Allocation over List<T> for Hashing
+**Learning:** In C#, replacing `List<T>` with `stackalloc Span<T>` for small, fixed-size pixel arrays in hot paths (like hashing algorithms) provides a substantial performance boost by eliminating heap allocations and GC pressure.
+**Action:** When finding medians or processing small, fixed-size data within inner loops, default to using stack-allocated Spans instead of List or Array instantiations.

--- a/DuplaImage.Lib/Hashes/DCTHash.cs
+++ b/DuplaImage.Lib/Hashes/DCTHash.cs
@@ -44,10 +44,11 @@ namespace DuplaImage.Lib.Hashes {
             }
 
             // Calculate median
-            List<float> pixelList = new(dctHashPixels);
-            pixelList.Sort();
+            Span<float> sortedPixels = stackalloc float[64];
+            dctHashPixels.AsSpan().CopyTo(sortedPixels);
+            sortedPixels.Sort();
             // Even amount of pixels
-            float median = (pixelList[31] + pixelList[32]) / 2;
+            float median = (sortedPixels[31] + sortedPixels[32]) / 2;
 
             // Iterate pixels and set them to 1 if over median and 0 if lower.
             ulong hash = CalculateHash(dctHashPixels, median);

--- a/DuplaImage.Lib/Hashes/MedianHash256.cs
+++ b/DuplaImage.Lib/Hashes/MedianHash256.cs
@@ -20,10 +20,11 @@ namespace DuplaImage.Lib.Hashes {
             ReadOnlySpan<byte> pixelSpan = pixels;
 
             // Calculate median
-            List<byte> pixelList = new(pixels);
-            pixelList.Sort();
+            Span<byte> sortedPixels = stackalloc byte[256];
+            pixelSpan.CopyTo(sortedPixels);
+            sortedPixels.Sort();
             // Even amount of pixels
-            byte median = (byte)((pixelList[127] + pixelList[128]) / 2);
+            byte median = (byte)((sortedPixels[127] + sortedPixels[128]) / 2);
 
             // Iterate pixels and set them to 1 if over median and 0 if lower.
             ulong[] hash = CalculateHash(pixelSpan, median);

--- a/DuplaImage.Lib/Hashes/MedianHash64.cs
+++ b/DuplaImage.Lib/Hashes/MedianHash64.cs
@@ -20,10 +20,11 @@ namespace DuplaImage.Lib.Hashes {
             ReadOnlySpan<byte> pixelSpan = pixels;
 
             // Calculate median
-            List<byte> pixelList = new(pixels);
-            pixelList.Sort();
+            Span<byte> sortedPixels = stackalloc byte[64];
+            pixelSpan.CopyTo(sortedPixels);
+            sortedPixels.Sort();
             // Even amount of pixels
-            byte median = (byte)((pixelList[31] + pixelList[32]) / 2);
+            byte median = (byte)((sortedPixels[31] + sortedPixels[32]) / 2);
 
             // Iterate pixels and set them to 1 if over median and 0 if lower.
             ulong hash = CalculateHash(pixelSpan, median);


### PR DESCRIPTION
💡 What: Replaced `new List<T>` allocations with `stackalloc Span<T>` in `MedianHash64`, `MedianHash256`, and `DCTHash` for finding medians of pixel arrays.
🎯 Why: Image hashing is often run over thousands of images. Allocating lists for small 64-256 element buffers causes unnecessary GC pressure. Using stack allocation removes heap overhead entirely for this operation.
📊 Impact: Eliminates heap allocations during median calculation in these algorithms, reducing garbage collection pressure and speeding up the inner hashing loops.
🔬 Measurement: Verified compilation and code review success. Expected measurable reduction in memory allocations and execution time during bulk image hashing.

---
*PR created automatically by Jules for task [4549070681377990884](https://jules.google.com/task/4549070681377990884) started by @MrSquirrely*