### PR TITLE
🛡️ Sentinel: [CRITICAL] Harden ImageMagick policy to prevent SSRF and XXE

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-31 - [Secure ImageMagick Configuration]
+ **Vulnerability:** Unrestricted ImageMagick configuration can lead to SSRF, XXE, or other file-read vulnerabilities when parsing user-provided files due to various legacy and complex delegates and coders.
+ **Learning:** ImageMagick's delegates such as HTTP, HTTPS, MVG, MSL, EPHEMERAL, and URL can fetch remote content, or files from the disk when parsing an image.
+ **Prevention:** Use `ConfigurationFiles.Default.Policy.Data` to define a strict `<policymap>` disabling unwanted coders and paths before initializing `MagickNET`.

--- a/DuplaImage.ImageMagick/ImageMagickTransformer.cs
+++ b/DuplaImage.ImageMagick/ImageMagickTransformer.cs
@@ -1,11 +1,27 @@
 ﻿using System.IO;
 using ImageMagick;
+using ImageMagick.Configuration;
 
 namespace DuplaImage.Lib.ImageMagick {
     /// <summary>
     /// Implements IImageTransformer interface using Magick.NET for image transforms.
     /// </summary>
     public class ImageMagickTransformer : IImageTransformer {
+
+        static ImageMagickTransformer() {
+            var configFiles = ConfigurationFiles.Default;
+            configFiles.Policy.Data = @"<policymap>
+  <policy domain=""coder"" rights=""none"" pattern=""HTTP"" />
+  <policy domain=""coder"" rights=""none"" pattern=""HTTPS"" />
+  <policy domain=""coder"" rights=""none"" pattern=""MVG"" />
+  <policy domain=""coder"" rights=""none"" pattern=""MSL"" />
+  <policy domain=""coder"" rights=""none"" pattern=""EPHEMERAL"" />
+  <policy domain=""coder"" rights=""none"" pattern=""URL"" />
+  <policy domain=""path"" rights=""none"" pattern=""@*"" />
+  <policy domain=""path"" rights=""none"" pattern=""|*"" />
+</policymap>";
+            MagickNET.Initialize(configFiles);
+        }
 
         private readonly QuantizeSettings _settings = new() {
             ColorSpace = ColorSpace.Gray,


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unrestricted ImageMagick configuration can lead to SSRF, XXE, or other file-read vulnerabilities when parsing user-provided files due to various legacy and complex delegates and coders.
🎯 **Impact:** An attacker could craft a malicious image (e.g. SVG or MVG) that, when parsed by `DuplaImage.Lib`'s `ImageMagickTransformer`, causes the server to make unauthorized HTTP requests or read arbitrary files from the server's filesystem, leaking sensitive information.
🔧 **Fix:** Added a static constructor to `ImageMagickTransformer` that leverages `ConfigurationFiles.Default` to set a strict XML `<policymap>`. This explicitly disables risky coders (`HTTP`, `HTTPS`, `MVG`, `MSL`, `EPHEMERAL`, `URL`) and limits file-reading capabilities (`@*`, `|*`) before any `MagickImage` instantiations can occur.
✅ **Verification:** A test file imitating an SSRF attempt via SVG payload confirmed that ImageMagick refused the action once the tightened policy was active. Verified that the package successfully compiles via `dotnet build`.

---
*PR created automatically by Jules for task [4198919711913165346](https://jules.google.com/task/4198919711913165346) started by @MrSquirrely*