### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Magick.NET SSRF/XXE via strict policymap

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-07 - Magick.NET Unsafe Coders SSRF/XXE Risk
+**Vulnerability:** Magick.NET allows potentially unsafe remote/local fetch coders (HTTP, HTTPS, MVG, MSL, EPHEMERAL, URL) by default unless explicitly disabled, leading to Server-Side Request Forgery (SSRF) and XML External Entity (XXE) vulnerabilities when processing user-provided image streams.
+**Learning:** We must apply a restrictive `policymap` via `MagickNET.Initialize()` early in application startup, for instance via a static constructor, to securely disable these coders in `DuplaImage.Lib.ImageMagick` before any image processing occurs.
+**Prevention:** Always initialize Magick.NET with an explicitly configured strict policy map setting the rights of remote/unsafe coders to "none". Ensure no direct invocations of Magick functions occur prior to this initialization.

--- a/DuplaImage.ImageMagick/ImageMagickTransformer.cs
+++ b/DuplaImage.ImageMagick/ImageMagickTransformer.cs
@@ -1,11 +1,26 @@
 ﻿using System.IO;
 using ImageMagick;
+using ImageMagick.Configuration;
 
 namespace DuplaImage.Lib.ImageMagick {
     /// <summary>
     /// Implements IImageTransformer interface using Magick.NET for image transforms.
     /// </summary>
     public class ImageMagickTransformer : IImageTransformer {
+        static ImageMagickTransformer() {
+            // Secure Magick.NET by disabling unsafe coders to prevent SSRF and XXE
+            string policyXml = @"<policymap>
+  <policy domain=""coder"" rights=""none"" pattern=""HTTP"" />
+  <policy domain=""coder"" rights=""none"" pattern=""HTTPS"" />
+  <policy domain=""coder"" rights=""none"" pattern=""MVG"" />
+  <policy domain=""coder"" rights=""none"" pattern=""MSL"" />
+  <policy domain=""coder"" rights=""none"" pattern=""EPHEMERAL"" />
+  <policy domain=""coder"" rights=""none"" pattern=""URL"" />
+</policymap>";
+            var configFiles = ConfigurationFiles.Default;
+            configFiles.Policy.Data = policyXml;
+            MagickNET.Initialize(configFiles);
+        }
 
         private readonly QuantizeSettings _settings = new() {
             ColorSpace = ColorSpace.Gray,


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Magick.NET SSRF/XXE via strict policymap

🚨 Severity: CRITICAL
💡 Vulnerability: Magick.NET allows potentially unsafe remote/local fetch coders (HTTP, HTTPS, MVG, MSL, EPHEMERAL, URL) by default, leading to SSRF and XXE when processing user-provided images.
🎯 Impact: An attacker could supply a malicious image/payload that forces the server to make internal network requests (SSRF) or read sensitive files (XXE).
🔧 Fix: Initialized Magick.NET with a strict `policymap` inside the `ImageMagickTransformer` static constructor to explicitly disable these unsafe coders globally before any image processing.
✅ Verification: Ran `dotnet build` successfully. Reviewed file changes to ensure the policy is correctly applied in the static constructor. Added security journal entry.

---
*PR created automatically by Jules for task [4244484111367201090](https://jules.google.com/task/4244484111367201090) started by @MrSquirrely*